### PR TITLE
修复剪藏微信文章时会丢失图片链接的问题+自动移除公众号文章末尾的无意义文字。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ mykv.db
 mykv.db.lock
 gin.log
 tem.file
+
+# Debug files
+debug/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,9 @@ RUN mkdir app && mkdir app/static/ && \
     cp -R static/ app/ && \
     cp -R website/ app/ && \
     cp -R sh/ app/ && \
-    cp -R script/ app/
+    cp -R script/ app/ && \
+    chmod +x app/docker-entrypoint.sh && \
+    sed -i 's/\r$//' app/docker-entrypoint.sh
     # cp zoneinfo.zip app/
     # docker-entrypoint.sh 运行后还会复制 static/ 到相应目录
 FROM alpine:latest
@@ -23,7 +25,7 @@ ENV TZ=Asia/Shanghai
 
 WORKDIR /app
 COPY --from=builder /home/workspace/app/ .
-RUN chmod +x docker-entrypoint.sh && sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \ 
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
     apk add --no-cache tzdata bash curl jq
 # bash curl about +5MB jq: a json cli
 # RUN pwd && ls

--- a/server/dao/couchdb.go
+++ b/server/dao/couchdb.go
@@ -163,7 +163,8 @@ func CouchDbMdFiletorage(db *kivik.DB, file_key string, text string) error {
 	if !exist && !delSign { // 数据库没这条记录
 		tools.Debug("数据库没这条记录")
 		fileDoc := FileDoc{
-			ID:       file_key,
+			ID:       strings.ToLower(file_key),
+			Path:     file_key,
 			Children: []string{leftId},
 			Ctime:    now,
 			Mtime:    now,
@@ -171,17 +172,18 @@ func CouchDbMdFiletorage(db *kivik.DB, file_key string, text string) error {
 			Type:     "plain",
 			Deleted:  false,
 		}
-		_, err = db.Put(context.TODO(), file_key, fileDoc)
+		_, err = db.Put(context.TODO(), strings.ToLower(file_key), fileDoc)
 		if err != nil {
 			return err
 		}
 	} else if (!exist && delSign) || (exist && !delSign) { // 数据库有记录
 		var fileNodeDoc FileDoc
-		db.Get(context.TODO(), file_key).ScanDoc(&fileNodeDoc)
+		db.Get(context.TODO(), strings.ToLower(file_key)).ScanDoc(&fileNodeDoc)
 		tools.Debug("数据库有记录")
 		fileDoc := FileDoc{
 			Rev:      fileNodeDoc.Rev,
-			ID:       file_key,
+			ID:       strings.ToLower(file_key),
+			Path:     file_key,
 			Children: []string{leftId},
 			Ctime:    now,
 			Mtime:    now,
@@ -189,7 +191,7 @@ func CouchDbMdFiletorage(db *kivik.DB, file_key string, text string) error {
 			Type:     "plain",
 			Deleted:  false,
 		}
-		_, err := db.Put(context.TODO(), file_key, fileDoc)
+		_, err := db.Put(context.TODO(), strings.ToLower(file_key), fileDoc)
 		if err != nil {
 			return err
 		}

--- a/server/dao/type.go
+++ b/server/dao/type.go
@@ -17,12 +17,14 @@ type PostJson struct {
 type FileDoc struct {
 	ID       string   `json:"_id"`
 	Rev      string   `json:"_rev,omitempty"`
+	Path     string   `json:"path"`
 	Children []string `json:"children"`
 	Ctime    int64    `json:"ctime"`
 	Mtime    int64    `json:"mtime"`
 	Size     int      `json:"size"`
 	Type     string   `json:"type"`
 	Deleted  bool     `json:"deleted"`
+	Eden     struct{} `json:"eden"`
 }
 
 // CouchDB Json struct


### PR DESCRIPTION
1. 当前版本会丢失公众号的图片链接
![image](https://github.com/user-attachments/assets/4fc0ff54-285f-41b8-a0ff-ec46c3e46b8c)
2. 当前版本剪藏公众号文章时末尾会有一些无意义的文字引导
![image](https://github.com/user-attachments/assets/21376388-fd2a-40db-a9b3-6a73dd29085e)
